### PR TITLE
Update default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ Currently supported options:
 
 | Name | Since | Example | Description |
 |------|:-----:|:-------:|-------------|
-| `user` | `1.0.0` | _apache_ | GitHub username or organization
-| `repo` | `1.0.0` | _spark_ | GitHub repository name for provided user
-| `batch` | `1.0.0` | _100_ | number of pull requests to fetch, default is 100 (single page), must be >= 1 and <= 1000
+| `user` | `1.0.0` | _apache_ | GitHub username or organization, default is `apache`
+| `repo` | `1.0.0` | _spark_ | GitHub repository name for provided user, default is `spark`
+| `batch` | `1.0.0` | _100_ | number of pull requests to fetch, default is 25, must be >= 1 and <= 1000
 | `token` | `1.0.0` | _auth_token_ | authentication token to increase rate limit from 60 to 5000, see [GitHub Auth for more info](https://developer.github.com/v3/#oauth2-token-sent-in-a-header)
 | `cacheDir` | `1.0.0` | _file:/tmp/.spark-github-pr_ | directory to store cached pull requests information, currently required to be shared folder on local file system or directory on HDFS.
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ Currently supported options:
 
 ### Scala API
 ```scala
+// Load default number of pull requests from apache/spark
+val df = sqlContext.read.format("com.github.lightcopy.spark.pr").load().
+  select("number", "title", "user.login")
+
 val df = sqlContext.read.format("com.github.lightcopy.spark.pr").
   option("user", "apache").option("repo", "spark").load().
   select("number", "title", "state", "base.repo.full_name", "user.login", "commits")

--- a/src/main/scala/com/github/lightcopy/spark/pr/PullRequestRelation.scala
+++ b/src/main/scala/com/github/lightcopy/spark/pr/PullRequestRelation.scala
@@ -52,19 +52,25 @@ class PullRequestRelation(
   val maxPageSize = 100
   val maxBatchSize = 1000
 
+  val defaultUser = "apache"
+  val defaultRepo = "spark"
+  val defaultBatchSize = 25 // this is an arbitrary number, should be less than 60
+
   // User and repository to fetch, together they create user/repository pair
   private[spark] val user: String = parameters.get("user") match {
     case Some(username) if username.trim.nonEmpty => username.trim
-    case other => sys.error(
-      "Expected 'user' option, none/empty provided. " +
-      "'user' option is either GitHub username or organization name")
+    case Some(other) => sys.error(
+      "Expected non-empty 'user' option, found empty value. 'user' option is either GitHub " +
+      s"username or organization name, default value is $defaultUser")
+    case None => defaultUser
   }
 
   private[spark] val repo: String = parameters.get("repo") match {
     case Some(repository) if repository.trim.nonEmpty => repository.trim
-    case other => sys.error(
-      "Expected 'repo' option, none/empty provided. " +
-      "'repo' options is repository name without username prefix")
+    case Some(other) => sys.error(
+      "Expected non-empty 'repo' option, found empty value. 'repo' option is repository name " +
+      s"without username prefix, default value is $defaultRepo")
+    case None => defaultRepo
   }
   logger.info(s"$user/$repo repository is selected")
 
@@ -81,7 +87,7 @@ class PullRequestRelation(
         throw new RuntimeException(
           s"Invalid batch size $size, should be positive integer, see cause for more info", err)
     }
-    case None => maxPageSize
+    case None => defaultBatchSize
   }
   logger.info(s"Batch size $batchSize is selected")
 

--- a/src/test/scala/com/github/lightcopy/spark/pr/PullRequestRelationSuite.scala
+++ b/src/test/scala/com/github/lightcopy/spark/pr/PullRequestRelationSuite.scala
@@ -43,12 +43,10 @@ class PullRequestRelationSuite extends UnitTestSuite with SparkLocal with HttpTe
     startSparkSession()
   }
 
-  test("fail to extract username") {
+  test("return default username when none is provided") {
     val sqlContext = spark.sqlContext
-    val err = intercept[RuntimeException] {
-      new PullRequestRelation(sqlContext, Map.empty)
-    }
-    err.getMessage.contains("Expected 'user' option") should be (true)
+    val relation = new PullRequestRelation(sqlContext, Map.empty)
+    relation.user should be (relation.defaultUser)
   }
 
   test("extract empty username") {
@@ -56,20 +54,18 @@ class PullRequestRelationSuite extends UnitTestSuite with SparkLocal with HttpTe
     var err = intercept[RuntimeException] {
       new PullRequestRelation(sqlContext, Map("user" -> ""))
     }
-    err.getMessage.contains("Expected 'user' option") should be (true)
+    err.getMessage.contains("Expected non-empty 'user' option") should be (true)
 
     err = intercept[RuntimeException] {
       new PullRequestRelation(sqlContext, Map("user" -> "  "))
     }
-    err.getMessage.contains("Expected 'user' option") should be (true)
+    err.getMessage.contains("Expected non-empty 'user' option") should be (true)
   }
 
-  test("fail to extract repository") {
+  test("return default repository when none is provided") {
     val sqlContext = spark.sqlContext
-    val err = intercept[RuntimeException] {
-      new PullRequestRelation(sqlContext, Map("user" -> "user"))
-    }
-    err.getMessage.contains("Expected 'repo' option") should be (true)
+    val relation = new PullRequestRelation(sqlContext, Map("user" -> "user"))
+    relation.repo should be (relation.defaultRepo)
   }
 
   test("extract empty repository") {
@@ -77,12 +73,12 @@ class PullRequestRelationSuite extends UnitTestSuite with SparkLocal with HttpTe
     var err = intercept[RuntimeException] {
       new PullRequestRelation(sqlContext, Map("user" -> "user", "repo" -> ""))
     }
-    err.getMessage.contains("Expected 'repo' option") should be (true)
+    err.getMessage.contains("Expected non-empty 'repo' option") should be (true)
 
     err = intercept[RuntimeException] {
       new PullRequestRelation(sqlContext, Map("user" -> "user", "repo" -> "  "))
     }
-    err.getMessage.contains("Expected 'repo' option") should be (true)
+    err.getMessage.contains("Expected non-empty 'repo' option") should be (true)
   }
 
   test("extract username, repository") {
@@ -137,7 +133,7 @@ class PullRequestRelationSuite extends UnitTestSuite with SparkLocal with HttpTe
   test("select default or valid batch size") {
     val sqlContext = spark.sqlContext
     var relation = new PullRequestRelation(sqlContext, Map("user" -> "user", "repo" -> "repo"))
-    relation.batchSize should be (relation.maxPageSize)
+    relation.batchSize should be (relation.defaultBatchSize)
 
     relation = new PullRequestRelation(sqlContext,
       Map("user" -> "user", "repo" -> "repo", "batch" -> "140"))


### PR DESCRIPTION
This PR updates default values, so now:
- `user` option is `apache` by default, if not specified
- `repo` option is `spark` by default, if not specified
- `batch` option is `25` by default, due to upper limit of 60 requests per hour

So now you can query PRs with simple command:
```scala
val df = sqlContext.read.format("com.github.lightcopy.spark.pr").load()
// will fetch 25 pull requests from apache/spark
df.show()
```