### PR TITLE
Add pull request stream source

### DIFF
--- a/src/main/scala/com/github/lightcopy/spark/pr/DefaultSource.scala
+++ b/src/main/scala/com/github/lightcopy/spark/pr/DefaultSource.scala
@@ -17,16 +17,42 @@
 package com.github.lightcopy.spark.pr
 
 import org.apache.spark.sql.SQLContext
-import org.apache.spark.sql.sources.{BaseRelation, RelationProvider}
+import org.apache.spark.sql.execution.streaming.Source
+import org.apache.spark.sql.sources.{BaseRelation, RelationProvider, StreamSourceProvider}
+import org.apache.spark.sql.types.StructType
 
 /**
  * Default source provider for GitHub PR datasource.
- * Schema inferrence is not supported for now.
+ * Schema inferrence is not required and user-defined schema is not supported for now.
+ * Source also provides stream source.
  */
-class DefaultSource extends RelationProvider {
+class DefaultSource extends RelationProvider with StreamSourceProvider {
   override def createRelation(
       sqlContext: SQLContext,
       parameters: Map[String, String]): BaseRelation = {
     new PullRequestRelation(sqlContext, parameters)
+  }
+
+  override def sourceSchema(
+      sqlContext: SQLContext,
+      schema: Option[StructType],
+      providerName: String,
+      parameters: Map[String, String]): (String, StructType) = {
+    require(schema.isEmpty, s"User-defined schema is not supported for provider $providerName")
+    // validate all options by creating pull request relation
+    val relation = createRelation(sqlContext, parameters)
+    // seems that provider name is not required, pass it for safety reasons
+    (providerName, relation.schema)
+  }
+
+  override def createSource(
+      sqlContext: SQLContext,
+      metadataPath: String,
+      schema: Option[StructType],
+      providerName: String,
+      parameters: Map[String, String]): Source = {
+    require(schema.isEmpty, s"User-defined schema is not supported for provider $providerName")
+    new PullRequestStreamSource(sqlContext, new PullRequestRelation(sqlContext, parameters),
+      metadataPath)
   }
 }

--- a/src/main/scala/com/github/lightcopy/spark/pr/DefaultSource.scala
+++ b/src/main/scala/com/github/lightcopy/spark/pr/DefaultSource.scala
@@ -41,7 +41,7 @@ class DefaultSource extends RelationProvider with StreamSourceProvider {
     require(schema.isEmpty, s"User-defined schema is not supported for provider $providerName")
     // validate all options by creating pull request relation
     val relation = createRelation(sqlContext, parameters)
-    // seems that provider name is not required, pass it for safety reasons
+    // seems that provider name is not required, still pass it for safety reasons
     (providerName, relation.schema)
   }
 

--- a/src/main/scala/com/github/lightcopy/spark/pr/PullRequestStreamSource.scala
+++ b/src/main/scala/com/github/lightcopy/spark/pr/PullRequestStreamSource.scala
@@ -16,14 +16,19 @@
 
 package com.github.lightcopy.spark.pr
 
+import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.sql.{DataFrame, SQLContext}
 import org.apache.spark.sql.execution.streaming.{LongOffset, Offset, Source}
-import org.apache.spark.sql.types.{LongType, StructField, StructType}
+import org.apache.spark.sql.types.StructType
+
+import org.slf4j.LoggerFactory
 
 /**
  * [[PullRequestStreamSource]] is built on top of pull request relation and simply provides ability
  * to query GitHub multiple times without any filtering on offsets. Every time batch will be
  * created based on current fetched data from GitHub, no options are adjusted, e.g. batch size.
+ * Offsets for streaming are incremented after each successful batch of pull requests, with internal
+ * polling interval applied.
  */
 class PullRequestStreamSource(
     @transient private val sqlContext: SQLContext,
@@ -31,16 +36,55 @@ class PullRequestStreamSource(
     private val metadataPath: String)
   extends Source {
 
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  // Warn user if polling delay is less than internal polling interval, in this case it should
+  // default to internal metric
+  val streamingPollingDelay = sqlContext.getConf("spark.sql.streaming.pollingDelay")
+  if (PullRequestStreamSource.delayAsMs > JavaUtils.timeStringAsMs(streamingPollingDelay)) {
+    logger.warn(s"Internal delay is greater than streaming polling delay " +
+      s"$streamingPollingDelay, and will bounded by ${PullRequestStreamSource.delayAsMs} ms")
+  }
+
+  // time snapshot to keep track of internal delay
+  private var timeSnapshot: Long = 0L
+  // next batch offset, just increment it by 1 for each batch
+  private var nextOffset: Option[Offset] = Some(LongOffset(0L))
+
   /** Return exactly the same schema of base relation for stream source */
   override def schema: StructType = baseRelation.schema
 
   /** Return none offset, current implementation relies on updates from GitHub */
-  override def getOffset: Option[Offset] = Some(new LongOffset(0))
+  override def getOffset: Option[Offset] = synchronized {
+    nextOffset match {
+      case Some(offset: LongOffset) =>
+        val startTime = System.nanoTime
+        val diff = startTime - timeSnapshot
+        if (diff >= PullRequestStreamSource.DELAY_NANOSECONDS) {
+          nextOffset = Some(offset + 1L)
+          timeSnapshot = startTime
+        } else {
+          logger.debug(s"Polling delay is not reached with diff = $diff, wait for the next check")
+        }
+      case other =>
+        logger.warn(s"Cannot process offset $other, wait for the next check")
+    }
+    nextOffset
+  }
 
   override def getBatch(start: Option[Offset], end: Offset): DataFrame = {
-    sqlContext.createDataFrame(baseRelation.buildScan, schema)
+    sqlContext.createDataFrame(baseRelation.buildScan(), schema)
   }
 
   /** Stop this source and free any resources it has allocated. */
   override def stop(): Unit = { }
+}
+
+private[pr] object PullRequestStreamSource {
+  // delay of 59 seconds in nanoseconds, represents internal polling interval, after which pull
+  // requests are available
+  val DELAY_NANOSECONDS = 59000000000L
+
+  /** Return delay as milliseconds to compare with streaming configuration */
+  def delayAsMs: Long = DELAY_NANOSECONDS / 1e6.toInt
 }

--- a/src/main/scala/com/github/lightcopy/spark/pr/PullRequestStreamSource.scala
+++ b/src/main/scala/com/github/lightcopy/spark/pr/PullRequestStreamSource.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 Lightcopy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.lightcopy.spark.pr
+
+import org.apache.spark.sql.{DataFrame, SQLContext}
+import org.apache.spark.sql.execution.streaming.{LongOffset, Offset, Source}
+import org.apache.spark.sql.types.{LongType, StructField, StructType}
+
+/**
+ * [[PullRequestStreamSource]] is built on top of pull request relation and simply provides ability
+ * to query GitHub multiple times without any filtering on offsets. Every time batch will be
+ * created based on current fetched data from GitHub, no options are adjusted, e.g. batch size.
+ */
+class PullRequestStreamSource(
+    @transient private val sqlContext: SQLContext,
+    @transient private val baseRelation: PullRequestRelation,
+    private val metadataPath: String)
+  extends Source {
+
+  /** Return exactly the same schema of base relation for stream source */
+  override def schema: StructType = baseRelation.schema
+
+  /** Return none offset, current implementation relies on updates from GitHub */
+  override def getOffset: Option[Offset] = Some(new LongOffset(0))
+
+  override def getBatch(start: Option[Offset], end: Offset): DataFrame = {
+    sqlContext.createDataFrame(baseRelation.buildScan, schema)
+  }
+
+  /** Stop this source and free any resources it has allocated. */
+  override def stop(): Unit = { }
+}

--- a/src/main/scala/com/github/lightcopy/spark/pr/PullRequestStreamSource.scala
+++ b/src/main/scala/com/github/lightcopy/spark/pr/PullRequestStreamSource.scala
@@ -47,9 +47,9 @@ class PullRequestStreamSource(
   }
 
   // time snapshot to keep track of internal delay
-  private var timeSnapshot: Long = 0L
+  private[pr] var timeSnapshot: Long = 0L
   // next batch offset, just increment it by 1 for each batch
-  private var nextOffset: Option[Offset] = Some(LongOffset(0L))
+  private[pr] var nextOffset: Option[Offset] = Some(LongOffset(0L))
 
   /** Return exactly the same schema of base relation for stream source */
   override def schema: StructType = baseRelation.schema

--- a/src/test/scala/com/github/lightcopy/spark/pr/DefaultSourceSuite.scala
+++ b/src/test/scala/com/github/lightcopy/spark/pr/DefaultSourceSuite.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016 Lightcopy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.lightcopy.spark.pr
+
+import org.apache.spark.sql.types.{LongType, StructField, StructType}
+
+import com.github.lightcopy.testutil.{SparkLocal, UnitTestSuite}
+import com.github.lightcopy.testutil.implicits._
+
+class DefaultSourceSuite extends UnitTestSuite with SparkLocal {
+  override def beforeAll {
+    startSparkSession()
+  }
+
+  override def afterAll {
+    startSparkSession()
+  }
+
+  test("create pull request relation") {
+    val source = new DefaultSource()
+    val relation = source.createRelation(spark.sqlContext, Map.empty)
+    relation.isInstanceOf[PullRequestRelation] should be (true)
+  }
+
+  test("fail if user-defined schema is provided for streaming schema") {
+    val source = new DefaultSource()
+    val err = intercept[IllegalArgumentException] {
+      source.sourceSchema(spark.sqlContext, Some(StructType(StructField("a", LongType) :: Nil)),
+        "provider", Map.empty)
+    }
+    err.getMessage.contains("User-defined schema is not supported") should be (true)
+  }
+
+  test("return correct schema for streaming") {
+    // schema should be the same as for pull request relation
+    val source = new DefaultSource()
+    val relation = source.createRelation(spark.sqlContext, Map.empty)
+    val (provider, schema) = source.sourceSchema(spark.sqlContext, None, "provider", Map.empty)
+    provider should be ("provider")
+    schema should be (relation.schema)
+  }
+
+  test("fail if user-defined schema is provided for streaming source") {
+    val source = new DefaultSource()
+    val err = intercept[IllegalArgumentException] {
+      source.createSource(spark.sqlContext, "metadataPath",
+        Some(StructType(StructField("a", LongType) :: Nil)), "provider", Map.empty)
+    }
+    err.getMessage.contains("User-defined schema is not supported") should be (true)
+  }
+
+  test("create pull request stream source") {
+    val source = new DefaultSource()
+    val stream = source.createSource(spark.sqlContext, "metadata", None, "provider", Map.empty)
+    stream.isInstanceOf[PullRequestStreamSource] should be (true)
+  }
+}

--- a/src/test/scala/com/github/lightcopy/spark/pr/PullRequestStreamSourceSuite.scala
+++ b/src/test/scala/com/github/lightcopy/spark/pr/PullRequestStreamSourceSuite.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2016 Lightcopy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.lightcopy.spark.pr
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.execution.streaming.{LongOffset, Offset}
+
+import com.github.lightcopy.testutil.{SparkLocal, UnitTestSuite}
+import com.github.lightcopy.testutil.implicits._
+
+class PullRequestStreamSourceSuite extends UnitTestSuite with SparkLocal {
+  override def beforeAll {
+    startSparkSession()
+  }
+
+  override def afterAll {
+    startSparkSession()
+  }
+
+  test("validate internal delay const") {
+    PullRequestStreamSource.DELAY_NANOSECONDS should be (59 * 1e9)
+  }
+
+  test("validate internal delay const as ms") {
+    PullRequestStreamSource.delayAsMs should be (PullRequestStreamSource.DELAY_NANOSECONDS / 1e6)
+  }
+
+  test("validate initial time snapshot") {
+    val relation = new PullRequestRelation(spark.sqlContext, Map.empty)
+    val source = new PullRequestStreamSource(spark.sqlContext, relation, "metadata")
+    source.timeSnapshot should be (0L)
+  }
+
+  test("validate initial offset") {
+    val relation = new PullRequestRelation(spark.sqlContext, Map.empty)
+    val source = new PullRequestStreamSource(spark.sqlContext, relation, "metadata")
+    source.nextOffset should be (Some(LongOffset(0L)))
+  }
+
+  test("check schema for stream source") {
+    val relation = new PullRequestRelation(spark.sqlContext, Map.empty)
+    val source = new PullRequestStreamSource(spark.sqlContext, relation, "metadata")
+    source.schema should be (relation.schema)
+  }
+
+  test("get next offset for non-long offset") {
+    val relation = new PullRequestRelation(spark.sqlContext, Map.empty)
+    val source = new PullRequestStreamSource(spark.sqlContext, relation, "metadata")
+    // offset is invalid - return itself
+    source.nextOffset = Some(new Offset() {
+      override def compareTo(other: Offset): Int = 0
+    })
+    source.getOffset should be (source.nextOffset)
+  }
+
+  test("get next offset for diff < internal delay") {
+    val relation = new PullRequestRelation(spark.sqlContext, Map.empty)
+    val source = new PullRequestStreamSource(spark.sqlContext, relation, "metadata")
+    // should return unchanged offset, since internal delay is still applied
+    source.nextOffset = Some(new LongOffset(1L))
+    source.timeSnapshot = System.nanoTime
+    source.getOffset should be (source.nextOffset)
+  }
+
+  test("get next offset for diff >= internal delay") {
+    val relation = new PullRequestRelation(spark.sqlContext, Map.empty)
+    val source = new PullRequestStreamSource(spark.sqlContext, relation, "metadata")
+    // should return unchanged offset, since internal delay is still applied
+    source.nextOffset = Some(new LongOffset(1L))
+    source.timeSnapshot = 1L
+    source.getOffset should be (Some(new LongOffset(2L)))
+  }
+
+  test("get batch for offset") {
+    val relation = new PullRequestRelation(spark.sqlContext, Map.empty) {
+      override def buildScan(): RDD[Row] = spark.sparkContext.emptyRDD[Row]
+    }
+    val source = new PullRequestStreamSource(spark.sqlContext, relation, "metadata")
+    val df = source.getBatch(None, new LongOffset(1L))
+    df.schema should be (source.schema)
+    df.count should be (0)
+  }
+}


### PR DESCRIPTION
This PR adds structured streaming feature by introducing `PullRequestStreamSource` and `StreamSourceProvider` to the default source. Current implementation is fairly simple, we do not check offsets with GitHub, just periodically fetch pull requests using `PullRequestRelation`.

Note that we have to remove Spark 1.6.x from tests. After PR is merged, main branch will support only Spark 2.x, though there will be maintenance for Spark 1.x. in separate branch.

Tested manually and with unit-tests, usage below:
```scala
val df = spark.readStream.format("com.github.lightcopy.spark.pr").load()
val query = df.writeStream.format("console").
  option("checkpointLocation", "./checkpoint").start()
``` 

We also force polling interval to be at least 59 seconds, if `spark.sql.streaming.pollingDelay` is less than that, warning message is issued and internal polling interval is used.