### PR TITLE
Make mergeable field nullable

### DIFF
--- a/src/main/scala/com/github/lightcopy/spark/pr/PullRequestRelation.scala
+++ b/src/main/scala/com/github/lightcopy/spark/pr/PullRequestRelation.scala
@@ -144,8 +144,10 @@ class PullRequestRelation(
         StructField("url", StringType, true) ::
         StructField("html_url", StringType, true) :: Nil), true) ::
       // pull request statistics
+      // value of "mergeable" field can be true, false, or null. If the value is null, this means
+      // that the mergeability hasn't been computed yet.
       StructField("merged", BooleanType, false) ::
-      StructField("mergeable", BooleanType, false) ::
+      StructField("mergeable", BooleanType, true) ::
       StructField("comments", IntegerType, false) ::
       StructField("commits", IntegerType, false) ::
       StructField("additions", IntegerType, false) ::

--- a/src/main/scala/com/github/lightcopy/spark/pr/sources.scala
+++ b/src/main/scala/com/github/lightcopy/spark/pr/sources.scala
@@ -151,7 +151,11 @@ private[spark] object Utils {
           if (value.isInstanceOf[BigInt]) value.asInstanceOf[BigInt].intValue else value
         case LongType =>
           if (value.isInstanceOf[BigInt]) value.asInstanceOf[BigInt].longValue else value
-        case BooleanType | DoubleType | StringType => value
+        case BooleanType | DoubleType | StringType =>
+          if (!field.nullable && value == null) {
+            throw new IllegalStateException(s"Non-nullable field ${field.name} has value $value")
+          }
+          value
         case TimestampType =>
           if (value != null) {
             val format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX").parse(value.toString)


### PR DESCRIPTION
This PR makes `mergeable` field nullable according to GitHub API that field can have values `true`, `false`, `null`. Also added check on nullability vs null value in `Utils`.

This should be merged before #9, so it goes into package version for Spark 1.x as well.